### PR TITLE
Fix finding php_config.h on Ubuntu.

### DIFF
--- a/phpspy.h
+++ b/phpspy.h
@@ -5,7 +5,7 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <limits.h>
-#include <php/main/php_config.h>
+#include <main/php_config.h>
 #include <pthread.h>
 #include <regex.h>
 #include <signal.h>
@@ -26,7 +26,7 @@
 #include <unistd.h>
 #undef ZEND_DEBUG
 #define ZEND_DEBUG 0
-#include <php/main/SAPI.h>
+#include <main/SAPI.h>
 #undef snprintf
 #undef vsnprintf
 #undef HASH_ADD


### PR DESCRIPTION
On Ubuntu, when installing php-dev, the includes are within
a directory named by date, so just doing `php/main` in the
include path won't work. `php-config --includes` handles this
by adding `-I` flags with the right directories, but you need
to not use the leading `php` directory.